### PR TITLE
Removed short circuit from diff function

### DIFF
--- a/lib/motion.js
+++ b/lib/motion.js
@@ -67,7 +67,6 @@ MotionDetection.prototype.getLastImage = function() {
  *  @return {Number}
  */
 MotionDetection.prototype.diff = function(img1, img2) {
-  if (img1.length !== img2.length) return null;
   var i = 0;
   var changed = 0;
   while (i < (img1.length * 0.25)) {    


### PR DESCRIPTION
The short circuit can cause the detect function to report the wrong value, null, when 2 images are of different sizes. Without the short circuit the function responds properly to either an image RGB array or an image buffer coming from fs.readFile().